### PR TITLE
Use pre-built RedisJSON in CI

### DIFF
--- a/.github/actions/download-redis-module/action.yaml
+++ b/.github/actions/download-redis-module/action.yaml
@@ -1,0 +1,22 @@
+name: 'Download Redis Module'
+description: 'Download a Redis module based on the provided module name and version'
+inputs:
+  module_name:
+    description: 'The name of the Redis module to download'
+    required: true
+  target_path:
+    description: 'The path to save the downloaded Redis module'
+    required: true
+  module_version:
+    description: 'The version of the Redis module to download'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Download and cache Redis module
+      run: |
+        ubuntu_version=$(lsb_release -rs)
+        cpu_arch=$(uname -m)
+        url="https://redismodules.s3.amazonaws.com/${{ inputs.module_name }}/${{ inputs.module_name }}.Linux-ubuntu${ubuntu_version}-${cpu_arch}.${{ inputs.module_version }}.zip"
+        wget -O ${{ inputs.target_path }} $url
+      shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,36 +125,12 @@ jobs:
     - name: Run tests
       run: make test
 
-    - name: Checkout RedisJSON
-      if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.config.db-version != '6.2.13'
-      uses: actions/checkout@v4
+    - name: Download RedisJSON
+      uses: ./.github/actions/download-redis-module
       with:
-        repository: "RedisJSON/RedisJSON"
-        path: "./__ci/redis-json"
-        set-safe-directory: false
-
-      # When cargo is invoked, it'll go up many directories to see if it can find a workspace
-      # This will avoid this issue in what is admittedly a bit of a janky but still fully functional way
-      #
-      #   1. Copy the untouched file (into Cargo.toml.actual)
-      #   2. Exclude ./__ci/redis-json from the workspace
-      #      (preventing it from being compiled as a workspace module)
-      #   3. Build RedisJSON
-      #   4. Move the built RedisJSON Module (librejson.so) to /tmp
-      #   5. Restore Cargo.toml to its untouched state
-      #   6. Remove the RedisJSON Source code so it doesn't interfere with tests
-      #
-      # This shouldn't cause issues in the future so long as no profiles or patches
-      # are applied to the workspace Cargo.toml file
-    - name: Compile RedisJSON
-      if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.config.db-version != '6.2.13'
-      run: |
-        cp ./Cargo.toml ./Cargo.toml.actual
-        echo $'\nexclude = [\"./__ci/redis-json\"]' >> Cargo.toml
-        cargo +stable build --release --manifest-path ./__ci/redis-json/Cargo.toml
-        mv ./__ci/redis-json/target/release/librejson.so /tmp/librejson.so
-        rm ./Cargo.toml; mv ./Cargo.toml.actual ./Cargo.toml
-        rm -rf ./__ci/redis-json
+        module_name: rejson-oss
+        module_version: 2.8.8
+        target_path: ${{ env.REDIS_RS_REDIS_JSON_PATH }}
 
     - name: Run module-specific tests
       if: matrix.config.db-version != '6.2.13'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,6 +126,7 @@ jobs:
       run: make test
 
     - name: Download RedisJSON
+      if: steps.cache-redisjson.outputs.cache-hit != 'true' && matrix.config.db-version != '6.2.13'
       uses: ./.github/actions/download-redis-module
       with:
         module_name: rejson-oss


### PR DESCRIPTION
Simplify and speed up CI workflow by downloading
pre-built RedisJSON and introduce reusable action.